### PR TITLE
Throw the error, don't hide it

### DIFF
--- a/src/main/java/net/gpedro/integrations/slack/SlackApi.java
+++ b/src/main/java/net/gpedro/integrations/slack/SlackApi.java
@@ -1,5 +1,7 @@
 package net.gpedro.integrations.slack;
 
+import com.google.gson.JsonObject;
+
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.InputStream;
@@ -7,8 +9,6 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-
-import com.google.gson.JsonObject;
 
 public class SlackApi {
 
@@ -77,21 +77,14 @@ public class SlackApi {
                 response.append('\r');
             }
 
-            System.out.println(response.toString());
             rd.close();
             return response.toString();
-
         } catch (Exception e) {
-
-            e.printStackTrace();
-            return null;
-
+            throw new RuntimeException(e);
         } finally {
-
             if (connection != null) {
                 connection.disconnect();
             }
         }
     }
-
 }


### PR DESCRIPTION
Not throwing the error makes me very nervous. There are more elegant
ways of doing this, but just wrapping it in a RuntimeException is better
than nothing.

Also removed the printout of the response.