### PR TITLE
Enable support for Markdown in SlackAttachment

### DIFF
--- a/src/main/java/net/gpedro/integrations/slack/SlackAttachment.java
+++ b/src/main/java/net/gpedro/integrations/slack/SlackAttachment.java
@@ -1,261 +1,302 @@
 package net.gpedro.integrations.slack;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
-import java.util.ArrayList;
-import java.util.List;
-
+/**
+ * Represents an attachment in a slack webhook JSON message.
+ * 
+ * @author Gabriel Pedro
+ * @author David Webb
+ *
+ */
 public class SlackAttachment {
 
-    private static final String HEX_REGEX = "^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
-    private static final String FALLBACK = "fallback";
-    private static final String TEXT = "text";
-    private static final String PRETEXT = "pretext";
-    private static final String COLOR = "color";
-    private static final String FIELDS = "fields";
-    private static final String AUTHOR_NAME = "author_name";
-    private static final String AUTHOR_LINK = "author_link";
-    private static final String AUTHOR_ICON = "author_icon";
-    private static final String TITLE = "title";
-    private static final String TITLE_LINK = "title_link";
-    private static final String IMAGE_URL = "image_url";
-    private static final String THUMB_URL = "thumb_url";
+	private static final String HEX_REGEX = "^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
+	private static final String FALLBACK = "fallback";
+	private static final String TEXT = "text";
+	private static final String PRETEXT = "pretext";
+	private static final String COLOR = "color";
+	private static final String FIELDS = "fields";
+	private static final String AUTHOR_NAME = "author_name";
+	private static final String AUTHOR_LINK = "author_link";
+	private static final String AUTHOR_ICON = "author_icon";
+	private static final String TITLE = "title";
+	private static final String TITLE_LINK = "title_link";
+	private static final String IMAGE_URL = "image_url";
+	private static final String THUMB_URL = "thumb_url";
+	private static final String MRKDWN_IN = "mrkdwn_in";
 
-    private String fallback;
-    private String text;
-    private String pretext;
-    private String color;
-    private String authorName;
-    private String authorLink;
-    private String authorIcon;
-    private String title;
-    private String titleLink;
-    private String imageUrl;
-    private String thumbUrl;
-    private List<SlackField> fields = new ArrayList<SlackField>();
+	private String fallback;
+	private String text;
+	private String pretext;
+	private String color;
+	private String authorName;
+	private String authorLink;
+	private String authorIcon;
+	private String title;
+	private String titleLink;
+	private String imageUrl;
+	private String thumbUrl;
+	private Set<String> markdownAttributes = new HashSet<String>();
+	private List<SlackField> fields = new ArrayList<SlackField>();
 
-    public SlackAttachment addFields(SlackField field) {
-        this.fields.add(field);
+	public SlackAttachment addFields(SlackField field) {
+		this.fields.add(field);
 
-        return this;
-    }
+		return this;
+	}
 
-    private boolean isHex(String pair) {
-        return pair.matches(HEX_REGEX);
-    }
+	public SlackAttachment addMarkdownAttribute(String attr) {
+		this.markdownAttributes.add(attr);
 
-    private JsonArray prepareFields() {
-        final JsonArray data = new JsonArray();
-        for (SlackField field : fields) {
-            data.add(field.toJson());
-        }
+		return this;
+	}
 
-        return data;
-    }
+	private boolean isHex(String pair) {
+		return pair.matches(HEX_REGEX);
+	}
 
-    public SlackAttachment removeFields(int index) {
-        this.fields.remove(index);
+	private JsonArray prepareFields() {
+		final JsonArray data = new JsonArray();
+		for (SlackField field : fields) {
+			data.add(field.toJson());
+		}
 
-        return this;
-    }
+		return data;
+	}
 
-    public SlackAttachment setColor(String color) {
-        if (color != null) {
-            if (color.charAt(0) == '#') {
-                if (!isHex(color.substring(1))) {
-                    throw new IllegalArgumentException(
-                            "Invalid Hex Color @ SlackAttachment");
-                }
-            } else
-                if (!color.matches("^(good|warning|danger)$")) {
-                    throw new IllegalArgumentException(
-                            "Invalid PreDefined Color @ SlackAttachment");
-                }
-        }
+	public SlackAttachment removeFields(int index) {
+		this.fields.remove(index);
 
-        this.color = color;
+		return this;
+	}
 
-        return this;
-    }
+	private JsonArray prepareMarkdownAttributes() {
+		final JsonArray data = new JsonArray();
+		for (String attr : markdownAttributes) {
+			data.add(new JsonPrimitive(attr));
+		}
 
-    public SlackAttachment setFallback(String fallback) {
-        this.fallback = fallback;
+		return data;
+	}
 
-        return this;
-    }
+	public SlackAttachment removeMarkdownAttribute(String attr) {
+		this.markdownAttributes.remove(attr);
 
-    public SlackAttachment setFields(List<SlackField> fields) {
-        this.fields = fields;
+		return this;
+	}
 
-        return this;
-    }
+	public SlackAttachment setColor(String color) {
+		if (color != null) {
+			if (color.charAt(0) == '#') {
+				if (!isHex(color.substring(1))) {
+					throw new IllegalArgumentException("Invalid Hex Color @ SlackAttachment");
+				}
+			} else if (!color.matches("^(good|warning|danger)$")) {
+				throw new IllegalArgumentException("Invalid PreDefined Color @ SlackAttachment");
+			}
+		}
 
-    public SlackAttachment setPretext(String pretext) {
-        this.pretext = pretext;
+		this.color = color;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setText(String text) {
-        this.text = text;
+	public SlackAttachment setFallback(String fallback) {
+		this.fallback = fallback;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setAuthorName(String authorName) {
-        this.authorName = authorName;
+	public SlackAttachment setFields(List<SlackField> fields) {
+		this.fields = fields;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setAuthorLink(String authorLink) {
-        this.authorLink = authorLink;
+	public SlackAttachment setPretext(String pretext) {
+		this.pretext = pretext;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setAuthorIcon(String authorIcon) {
-        this.authorIcon = authorIcon;
+	public SlackAttachment setText(String text) {
+		this.text = text;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setTitle(String title) {
-        this.title = title;
+	public SlackAttachment setAuthorName(String authorName) {
+		this.authorName = authorName;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setTitleLink(String titleLink) {
-        this.titleLink = titleLink;
+	public SlackAttachment setAuthorLink(String authorLink) {
+		this.authorLink = authorLink;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+	public SlackAttachment setAuthorIcon(String authorIcon) {
+		this.authorIcon = authorIcon;
 
-        return this;
-    }
+		return this;
+	}
 
-    public SlackAttachment setThumbUrl(String thumbUrl) {
-        this.thumbUrl = thumbUrl;
+	public SlackAttachment setTitle(String title) {
+		this.title = title;
 
-        return this;
-    }
+		return this;
+	}
 
-    public JsonObject toJson() {
-        JsonObject data = new JsonObject();
+	public SlackAttachment setTitleLink(String titleLink) {
+		this.titleLink = titleLink;
 
-        if (fallback == null) {
-            throw new IllegalArgumentException(
-                    "Missing Fallback @ SlackAttachment");
-        } else {
-            data.addProperty(FALLBACK, fallback);
-        }
+		return this;
+	}
 
-        if (text != null) {
-            data.addProperty(TEXT, text);
-        }
+	public SlackAttachment setImageUrl(String imageUrl) {
+		this.imageUrl = imageUrl;
 
-        if (pretext != null) {
-            data.addProperty(PRETEXT, pretext);
-        }
+		return this;
+	}
 
-        if (color != null) {
-            data.addProperty(COLOR, color);
-        }
+	public SlackAttachment setThumbUrl(String thumbUrl) {
+		this.thumbUrl = thumbUrl;
 
-        if (authorName != null) {
-            data.addProperty(AUTHOR_NAME, authorName);
-        }
+		return this;
+	}
 
-        if (authorLink != null) {
-            data.addProperty(AUTHOR_LINK, authorLink);
-        }
+	public JsonObject toJson() {
+		JsonObject data = new JsonObject();
 
-        if (authorIcon != null) {
-            data.addProperty(AUTHOR_ICON, authorIcon);
-        }
+		if (fallback == null) {
+			throw new IllegalArgumentException("Missing Fallback @ SlackAttachment");
+		} else {
+			data.addProperty(FALLBACK, fallback);
+		}
 
-        if (title != null) {
-            data.addProperty(TITLE, title);
-        }
+		if (text != null) {
+			data.addProperty(TEXT, text);
+		}
 
-        if (titleLink != null) {
-            data.addProperty(TITLE_LINK, titleLink);
-        }
+		if (pretext != null) {
+			data.addProperty(PRETEXT, pretext);
+		}
 
-        if (imageUrl != null) {
-            data.addProperty(IMAGE_URL, imageUrl);
-        }
+		if (color != null) {
+			data.addProperty(COLOR, color);
+		}
 
-        if (thumbUrl != null) {
-            data.addProperty(THUMB_URL, thumbUrl);
-        }
+		if (authorName != null) {
+			data.addProperty(AUTHOR_NAME, authorName);
+		}
 
-        if (fields != null && fields.size() > 0) {
-            data.add(FIELDS, prepareFields());
-        }
+		if (authorLink != null) {
+			data.addProperty(AUTHOR_LINK, authorLink);
+		}
 
-        return data;
-    }
+		if (authorIcon != null) {
+			data.addProperty(AUTHOR_ICON, authorIcon);
+		}
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+		if (title != null) {
+			data.addProperty(TITLE, title);
+		}
 
-        SlackAttachment that = (SlackAttachment) o;
+		if (titleLink != null) {
+			data.addProperty(TITLE_LINK, titleLink);
+		}
 
-        if (fallback != null ? !fallback.equals(that.fallback) : that.fallback != null) return false;
-        if (text != null ? !text.equals(that.text) : that.text != null) return false;
-        if (pretext != null ? !pretext.equals(that.pretext) : that.pretext != null) return false;
-        if (color != null ? !color.equals(that.color) : that.color != null) return false;
-        if (authorName != null ? !authorName.equals(that.authorName) : that.authorName != null) return false;
-        if (authorLink != null ? !authorLink.equals(that.authorLink) : that.authorLink != null) return false;
-        if (authorIcon != null ? !authorIcon.equals(that.authorIcon) : that.authorIcon != null) return false;
-        if (title != null ? !title.equals(that.title) : that.title != null) return false;
-        if (titleLink != null ? !titleLink.equals(that.titleLink) : that.titleLink != null) return false;
-        if (imageUrl != null ? !imageUrl.equals(that.imageUrl) : that.imageUrl != null) return false;
-        if (thumbUrl != null ? !thumbUrl.equals(that.thumbUrl) : that.thumbUrl != null) return false;
-        return !(fields != null ? !fields.equals(that.fields) : that.fields != null);
+		if (imageUrl != null) {
+			data.addProperty(IMAGE_URL, imageUrl);
+		}
 
-    }
+		if (thumbUrl != null) {
+			data.addProperty(THUMB_URL, thumbUrl);
+		}
 
-    @Override
-    public int hashCode() {
-        int result = fallback != null ? fallback.hashCode() : 0;
-        result = 31 * result + (text != null ? text.hashCode() : 0);
-        result = 31 * result + (pretext != null ? pretext.hashCode() : 0);
-        result = 31 * result + (color != null ? color.hashCode() : 0);
-        result = 31 * result + (authorName != null ? authorName.hashCode() : 0);
-        result = 31 * result + (authorLink != null ? authorLink.hashCode() : 0);
-        result = 31 * result + (authorIcon != null ? authorIcon.hashCode() : 0);
-        result = 31 * result + (title != null ? title.hashCode() : 0);
-        result = 31 * result + (titleLink != null ? titleLink.hashCode() : 0);
-        result = 31 * result + (imageUrl != null ? imageUrl.hashCode() : 0);
-        result = 31 * result + (thumbUrl != null ? thumbUrl.hashCode() : 0);
-        result = 31 * result + (fields != null ? fields.hashCode() : 0);
-        return result;
-    }
+		if (markdownAttributes != null) {
+			data.add(MRKDWN_IN, prepareMarkdownAttributes());
+		}
 
-    @Override
-    public String toString() {
-        return "SlackAttachment{" +
-                "fallback='" + fallback + '\'' +
-                ", text='" + text + '\'' +
-                ", pretext='" + pretext + '\'' +
-                ", color='" + color + '\'' +
-                ", authorName='" + authorName + '\'' +
-                ", authorLink='" + authorLink + '\'' +
-                ", authorIcon='" + authorIcon + '\'' +
-                ", title='" + title + '\'' +
-                ", titleLink='" + titleLink + '\'' +
-                ", imageUrl='" + imageUrl + '\'' +
-                ", thumbUrl='" + thumbUrl + '\'' +
-                ", fields=" + fields +
-                '}';
-    }
+		if (fields != null && fields.size() > 0) {
+			data.add(FIELDS, prepareFields());
+		}
+
+		return data;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		SlackAttachment that = (SlackAttachment) o;
+
+		if (fallback != null ? !fallback.equals(that.fallback) : that.fallback != null)
+			return false;
+		if (text != null ? !text.equals(that.text) : that.text != null)
+			return false;
+		if (pretext != null ? !pretext.equals(that.pretext) : that.pretext != null)
+			return false;
+		if (color != null ? !color.equals(that.color) : that.color != null)
+			return false;
+		if (authorName != null ? !authorName.equals(that.authorName) : that.authorName != null)
+			return false;
+		if (authorLink != null ? !authorLink.equals(that.authorLink) : that.authorLink != null)
+			return false;
+		if (authorIcon != null ? !authorIcon.equals(that.authorIcon) : that.authorIcon != null)
+			return false;
+		if (title != null ? !title.equals(that.title) : that.title != null)
+			return false;
+		if (titleLink != null ? !titleLink.equals(that.titleLink) : that.titleLink != null)
+			return false;
+		if (imageUrl != null ? !imageUrl.equals(that.imageUrl) : that.imageUrl != null)
+			return false;
+		if (thumbUrl != null ? !thumbUrl.equals(that.thumbUrl) : that.thumbUrl != null)
+			return false;
+		if (markdownAttributes != null ? !markdownAttributes.equals(that.markdownAttributes)
+				: that.markdownAttributes != null)
+			return false;
+		return !(fields != null ? !fields.equals(that.fields) : that.fields != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = fallback != null ? fallback.hashCode() : 0;
+		result = 31 * result + (text != null ? text.hashCode() : 0);
+		result = 31 * result + (pretext != null ? pretext.hashCode() : 0);
+		result = 31 * result + (color != null ? color.hashCode() : 0);
+		result = 31 * result + (authorName != null ? authorName.hashCode() : 0);
+		result = 31 * result + (authorLink != null ? authorLink.hashCode() : 0);
+		result = 31 * result + (authorIcon != null ? authorIcon.hashCode() : 0);
+		result = 31 * result + (title != null ? title.hashCode() : 0);
+		result = 31 * result + (titleLink != null ? titleLink.hashCode() : 0);
+		result = 31 * result + (imageUrl != null ? imageUrl.hashCode() : 0);
+		result = 31 * result + (thumbUrl != null ? thumbUrl.hashCode() : 0);
+		result = 31 * result + (markdownAttributes != null ? markdownAttributes.hashCode() : 0);
+		result = 31 * result + (fields != null ? fields.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "SlackAttachment{" + "fallback='" + fallback + '\'' + ", text='" + text + '\'' + ", pretext='" + pretext
+				+ '\'' + ", color='" + color + '\'' + ", authorName='" + authorName + '\'' + ", authorLink='" + authorLink
+				+ '\'' + ", authorIcon='" + authorIcon + '\'' + ", title='" + title + '\'' + ", titleLink='" + titleLink + '\''
+				+ ", imageUrl='" + imageUrl + '\'' + ", thumbUrl='" + thumbUrl + '\'' + ", markdownAttributes="
+				+ markdownAttributes + ", fields=" + fields + '}';
+	}
 }

--- a/src/main/java/net/gpedro/integrations/slack/SlackAttachment.java
+++ b/src/main/java/net/gpedro/integrations/slack/SlackAttachment.java
@@ -18,285 +18,285 @@ import com.google.gson.JsonPrimitive;
  */
 public class SlackAttachment {
 
-	private static final String HEX_REGEX = "^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
-	private static final String FALLBACK = "fallback";
-	private static final String TEXT = "text";
-	private static final String PRETEXT = "pretext";
-	private static final String COLOR = "color";
-	private static final String FIELDS = "fields";
-	private static final String AUTHOR_NAME = "author_name";
-	private static final String AUTHOR_LINK = "author_link";
-	private static final String AUTHOR_ICON = "author_icon";
-	private static final String TITLE = "title";
-	private static final String TITLE_LINK = "title_link";
-	private static final String IMAGE_URL = "image_url";
-	private static final String THUMB_URL = "thumb_url";
-	private static final String MRKDWN_IN = "mrkdwn_in";
+    private static final String HEX_REGEX = "^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
+    private static final String FALLBACK = "fallback";
+    private static final String TEXT = "text";
+    private static final String PRETEXT = "pretext";
+    private static final String COLOR = "color";
+    private static final String FIELDS = "fields";
+    private static final String AUTHOR_NAME = "author_name";
+    private static final String AUTHOR_LINK = "author_link";
+    private static final String AUTHOR_ICON = "author_icon";
+    private static final String TITLE = "title";
+    private static final String TITLE_LINK = "title_link";
+    private static final String IMAGE_URL = "image_url";
+    private static final String THUMB_URL = "thumb_url";
+    private static final String MRKDWN_IN = "mrkdwn_in";
 
-	private String fallback;
-	private String text;
-	private String pretext;
-	private String color;
-	private String authorName;
-	private String authorLink;
-	private String authorIcon;
-	private String title;
-	private String titleLink;
-	private String imageUrl;
-	private String thumbUrl;
-	private Set<String> markdownAttributes = new HashSet<String>();
-	private List<SlackField> fields = new ArrayList<SlackField>();
+    private String fallback;
+    private String text;
+    private String pretext;
+    private String color;
+    private String authorName;
+    private String authorLink;
+    private String authorIcon;
+    private String title;
+    private String titleLink;
+    private String imageUrl;
+    private String thumbUrl;
+    private Set<String> markdownAttributes = new HashSet<String>();
+    private List<SlackField> fields = new ArrayList<SlackField>();
 
-	public SlackAttachment addFields(SlackField field) {
-		this.fields.add(field);
+    public SlackAttachment addFields(SlackField field) {
+	this.fields.add(field);
 
-		return this;
+	return this;
+    }
+
+    public SlackAttachment addMarkdownAttribute(String attr) {
+	this.markdownAttributes.add(attr);
+
+	return this;
+    }
+
+    private boolean isHex(String pair) {
+	return pair.matches(HEX_REGEX);
+    }
+
+    private JsonArray prepareFields() {
+	final JsonArray data = new JsonArray();
+	for (SlackField field : fields) {
+	    data.add(field.toJson());
 	}
 
-	public SlackAttachment addMarkdownAttribute(String attr) {
-		this.markdownAttributes.add(attr);
+	return data;
+    }
 
-		return this;
+    public SlackAttachment removeFields(int index) {
+	this.fields.remove(index);
+
+	return this;
+    }
+
+    private JsonArray prepareMarkdownAttributes() {
+	final JsonArray data = new JsonArray();
+	for (String attr : markdownAttributes) {
+	    data.add(new JsonPrimitive(attr));
 	}
 
-	private boolean isHex(String pair) {
-		return pair.matches(HEX_REGEX);
-	}
+	return data;
+    }
 
-	private JsonArray prepareFields() {
-		final JsonArray data = new JsonArray();
-		for (SlackField field : fields) {
-			data.add(field.toJson());
+    public SlackAttachment removeMarkdownAttribute(String attr) {
+	this.markdownAttributes.remove(attr);
+
+	return this;
+    }
+
+    public SlackAttachment setColor(String color) {
+	if (color != null) {
+	    if (color.charAt(0) == '#') {
+		if (!isHex(color.substring(1))) {
+		    throw new IllegalArgumentException("Invalid Hex Color @ SlackAttachment");
 		}
-
-		return data;
+	    } else if (!color.matches("^(good|warning|danger)$")) {
+		throw new IllegalArgumentException("Invalid PreDefined Color @ SlackAttachment");
+	    }
 	}
 
-	public SlackAttachment removeFields(int index) {
-		this.fields.remove(index);
+	this.color = color;
 
-		return this;
+	return this;
+    }
+
+    public SlackAttachment setFallback(String fallback) {
+	this.fallback = fallback;
+
+	return this;
+    }
+
+    public SlackAttachment setFields(List<SlackField> fields) {
+	this.fields = fields;
+
+	return this;
+    }
+
+    public SlackAttachment setPretext(String pretext) {
+	this.pretext = pretext;
+
+	return this;
+    }
+
+    public SlackAttachment setText(String text) {
+	this.text = text;
+
+	return this;
+    }
+
+    public SlackAttachment setAuthorName(String authorName) {
+	this.authorName = authorName;
+
+	return this;
+    }
+
+    public SlackAttachment setAuthorLink(String authorLink) {
+	this.authorLink = authorLink;
+
+	return this;
+    }
+
+    public SlackAttachment setAuthorIcon(String authorIcon) {
+	this.authorIcon = authorIcon;
+
+	return this;
+    }
+
+    public SlackAttachment setTitle(String title) {
+	this.title = title;
+
+	return this;
+    }
+
+    public SlackAttachment setTitleLink(String titleLink) {
+	this.titleLink = titleLink;
+
+	return this;
+    }
+
+    public SlackAttachment setImageUrl(String imageUrl) {
+	this.imageUrl = imageUrl;
+
+	return this;
+    }
+
+    public SlackAttachment setThumbUrl(String thumbUrl) {
+	this.thumbUrl = thumbUrl;
+
+	return this;
+    }
+
+    public JsonObject toJson() {
+	JsonObject data = new JsonObject();
+
+	if (fallback == null) {
+	    throw new IllegalArgumentException("Missing Fallback @ SlackAttachment");
+	} else {
+	    data.addProperty(FALLBACK, fallback);
 	}
 
-	private JsonArray prepareMarkdownAttributes() {
-		final JsonArray data = new JsonArray();
-		for (String attr : markdownAttributes) {
-			data.add(new JsonPrimitive(attr));
-		}
-
-		return data;
+	if (text != null) {
+	    data.addProperty(TEXT, text);
 	}
 
-	public SlackAttachment removeMarkdownAttribute(String attr) {
-		this.markdownAttributes.remove(attr);
-
-		return this;
+	if (pretext != null) {
+	    data.addProperty(PRETEXT, pretext);
 	}
 
-	public SlackAttachment setColor(String color) {
-		if (color != null) {
-			if (color.charAt(0) == '#') {
-				if (!isHex(color.substring(1))) {
-					throw new IllegalArgumentException("Invalid Hex Color @ SlackAttachment");
-				}
-			} else if (!color.matches("^(good|warning|danger)$")) {
-				throw new IllegalArgumentException("Invalid PreDefined Color @ SlackAttachment");
-			}
-		}
-
-		this.color = color;
-
-		return this;
+	if (color != null) {
+	    data.addProperty(COLOR, color);
 	}
 
-	public SlackAttachment setFallback(String fallback) {
-		this.fallback = fallback;
-
-		return this;
+	if (authorName != null) {
+	    data.addProperty(AUTHOR_NAME, authorName);
 	}
 
-	public SlackAttachment setFields(List<SlackField> fields) {
-		this.fields = fields;
-
-		return this;
+	if (authorLink != null) {
+	    data.addProperty(AUTHOR_LINK, authorLink);
 	}
 
-	public SlackAttachment setPretext(String pretext) {
-		this.pretext = pretext;
-
-		return this;
+	if (authorIcon != null) {
+	    data.addProperty(AUTHOR_ICON, authorIcon);
 	}
 
-	public SlackAttachment setText(String text) {
-		this.text = text;
-
-		return this;
+	if (title != null) {
+	    data.addProperty(TITLE, title);
 	}
 
-	public SlackAttachment setAuthorName(String authorName) {
-		this.authorName = authorName;
-
-		return this;
+	if (titleLink != null) {
+	    data.addProperty(TITLE_LINK, titleLink);
 	}
 
-	public SlackAttachment setAuthorLink(String authorLink) {
-		this.authorLink = authorLink;
-
-		return this;
+	if (imageUrl != null) {
+	    data.addProperty(IMAGE_URL, imageUrl);
 	}
 
-	public SlackAttachment setAuthorIcon(String authorIcon) {
-		this.authorIcon = authorIcon;
-
-		return this;
+	if (thumbUrl != null) {
+	    data.addProperty(THUMB_URL, thumbUrl);
 	}
 
-	public SlackAttachment setTitle(String title) {
-		this.title = title;
-
-		return this;
+	if (markdownAttributes != null) {
+	    data.add(MRKDWN_IN, prepareMarkdownAttributes());
 	}
 
-	public SlackAttachment setTitleLink(String titleLink) {
-		this.titleLink = titleLink;
-
-		return this;
+	if (fields != null && fields.size() > 0) {
+	    data.add(FIELDS, prepareFields());
 	}
 
-	public SlackAttachment setImageUrl(String imageUrl) {
-		this.imageUrl = imageUrl;
+	return data;
+    }
 
-		return this;
-	}
+    @Override
+    public boolean equals(Object o) {
+	if (this == o)
+	    return true;
+	if (o == null || getClass() != o.getClass())
+	    return false;
 
-	public SlackAttachment setThumbUrl(String thumbUrl) {
-		this.thumbUrl = thumbUrl;
+	SlackAttachment that = (SlackAttachment) o;
 
-		return this;
-	}
+	if (fallback != null ? !fallback.equals(that.fallback) : that.fallback != null)
+	    return false;
+	if (text != null ? !text.equals(that.text) : that.text != null)
+	    return false;
+	if (pretext != null ? !pretext.equals(that.pretext) : that.pretext != null)
+	    return false;
+	if (color != null ? !color.equals(that.color) : that.color != null)
+	    return false;
+	if (authorName != null ? !authorName.equals(that.authorName) : that.authorName != null)
+	    return false;
+	if (authorLink != null ? !authorLink.equals(that.authorLink) : that.authorLink != null)
+	    return false;
+	if (authorIcon != null ? !authorIcon.equals(that.authorIcon) : that.authorIcon != null)
+	    return false;
+	if (title != null ? !title.equals(that.title) : that.title != null)
+	    return false;
+	if (titleLink != null ? !titleLink.equals(that.titleLink) : that.titleLink != null)
+	    return false;
+	if (imageUrl != null ? !imageUrl.equals(that.imageUrl) : that.imageUrl != null)
+	    return false;
+	if (thumbUrl != null ? !thumbUrl.equals(that.thumbUrl) : that.thumbUrl != null)
+	    return false;
+	if (markdownAttributes != null ? !markdownAttributes.equals(that.markdownAttributes)
+		: that.markdownAttributes != null)
+	    return false;
+	return !(fields != null ? !fields.equals(that.fields) : that.fields != null);
 
-	public JsonObject toJson() {
-		JsonObject data = new JsonObject();
+    }
 
-		if (fallback == null) {
-			throw new IllegalArgumentException("Missing Fallback @ SlackAttachment");
-		} else {
-			data.addProperty(FALLBACK, fallback);
-		}
+    @Override
+    public int hashCode() {
+	int result = fallback != null ? fallback.hashCode() : 0;
+	result = 31 * result + (text != null ? text.hashCode() : 0);
+	result = 31 * result + (pretext != null ? pretext.hashCode() : 0);
+	result = 31 * result + (color != null ? color.hashCode() : 0);
+	result = 31 * result + (authorName != null ? authorName.hashCode() : 0);
+	result = 31 * result + (authorLink != null ? authorLink.hashCode() : 0);
+	result = 31 * result + (authorIcon != null ? authorIcon.hashCode() : 0);
+	result = 31 * result + (title != null ? title.hashCode() : 0);
+	result = 31 * result + (titleLink != null ? titleLink.hashCode() : 0);
+	result = 31 * result + (imageUrl != null ? imageUrl.hashCode() : 0);
+	result = 31 * result + (thumbUrl != null ? thumbUrl.hashCode() : 0);
+	result = 31 * result + (markdownAttributes != null ? markdownAttributes.hashCode() : 0);
+	result = 31 * result + (fields != null ? fields.hashCode() : 0);
+	return result;
+    }
 
-		if (text != null) {
-			data.addProperty(TEXT, text);
-		}
-
-		if (pretext != null) {
-			data.addProperty(PRETEXT, pretext);
-		}
-
-		if (color != null) {
-			data.addProperty(COLOR, color);
-		}
-
-		if (authorName != null) {
-			data.addProperty(AUTHOR_NAME, authorName);
-		}
-
-		if (authorLink != null) {
-			data.addProperty(AUTHOR_LINK, authorLink);
-		}
-
-		if (authorIcon != null) {
-			data.addProperty(AUTHOR_ICON, authorIcon);
-		}
-
-		if (title != null) {
-			data.addProperty(TITLE, title);
-		}
-
-		if (titleLink != null) {
-			data.addProperty(TITLE_LINK, titleLink);
-		}
-
-		if (imageUrl != null) {
-			data.addProperty(IMAGE_URL, imageUrl);
-		}
-
-		if (thumbUrl != null) {
-			data.addProperty(THUMB_URL, thumbUrl);
-		}
-
-		if (markdownAttributes != null) {
-			data.add(MRKDWN_IN, prepareMarkdownAttributes());
-		}
-
-		if (fields != null && fields.size() > 0) {
-			data.add(FIELDS, prepareFields());
-		}
-
-		return data;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-
-		SlackAttachment that = (SlackAttachment) o;
-
-		if (fallback != null ? !fallback.equals(that.fallback) : that.fallback != null)
-			return false;
-		if (text != null ? !text.equals(that.text) : that.text != null)
-			return false;
-		if (pretext != null ? !pretext.equals(that.pretext) : that.pretext != null)
-			return false;
-		if (color != null ? !color.equals(that.color) : that.color != null)
-			return false;
-		if (authorName != null ? !authorName.equals(that.authorName) : that.authorName != null)
-			return false;
-		if (authorLink != null ? !authorLink.equals(that.authorLink) : that.authorLink != null)
-			return false;
-		if (authorIcon != null ? !authorIcon.equals(that.authorIcon) : that.authorIcon != null)
-			return false;
-		if (title != null ? !title.equals(that.title) : that.title != null)
-			return false;
-		if (titleLink != null ? !titleLink.equals(that.titleLink) : that.titleLink != null)
-			return false;
-		if (imageUrl != null ? !imageUrl.equals(that.imageUrl) : that.imageUrl != null)
-			return false;
-		if (thumbUrl != null ? !thumbUrl.equals(that.thumbUrl) : that.thumbUrl != null)
-			return false;
-		if (markdownAttributes != null ? !markdownAttributes.equals(that.markdownAttributes)
-				: that.markdownAttributes != null)
-			return false;
-		return !(fields != null ? !fields.equals(that.fields) : that.fields != null);
-
-	}
-
-	@Override
-	public int hashCode() {
-		int result = fallback != null ? fallback.hashCode() : 0;
-		result = 31 * result + (text != null ? text.hashCode() : 0);
-		result = 31 * result + (pretext != null ? pretext.hashCode() : 0);
-		result = 31 * result + (color != null ? color.hashCode() : 0);
-		result = 31 * result + (authorName != null ? authorName.hashCode() : 0);
-		result = 31 * result + (authorLink != null ? authorLink.hashCode() : 0);
-		result = 31 * result + (authorIcon != null ? authorIcon.hashCode() : 0);
-		result = 31 * result + (title != null ? title.hashCode() : 0);
-		result = 31 * result + (titleLink != null ? titleLink.hashCode() : 0);
-		result = 31 * result + (imageUrl != null ? imageUrl.hashCode() : 0);
-		result = 31 * result + (thumbUrl != null ? thumbUrl.hashCode() : 0);
-		result = 31 * result + (markdownAttributes != null ? markdownAttributes.hashCode() : 0);
-		result = 31 * result + (fields != null ? fields.hashCode() : 0);
-		return result;
-	}
-
-	@Override
-	public String toString() {
-		return "SlackAttachment{" + "fallback='" + fallback + '\'' + ", text='" + text + '\'' + ", pretext='" + pretext
-				+ '\'' + ", color='" + color + '\'' + ", authorName='" + authorName + '\'' + ", authorLink='" + authorLink
-				+ '\'' + ", authorIcon='" + authorIcon + '\'' + ", title='" + title + '\'' + ", titleLink='" + titleLink + '\''
-				+ ", imageUrl='" + imageUrl + '\'' + ", thumbUrl='" + thumbUrl + '\'' + ", markdownAttributes="
-				+ markdownAttributes + ", fields=" + fields + '}';
-	}
+    @Override
+    public String toString() {
+	return "SlackAttachment{" + "fallback='" + fallback + '\'' + ", text='" + text + '\'' + ", pretext='" + pretext
+		+ '\'' + ", color='" + color + '\'' + ", authorName='" + authorName + '\'' + ", authorLink='"
+		+ authorLink + '\'' + ", authorIcon='" + authorIcon + '\'' + ", title='" + title + '\''
+		+ ", titleLink='" + titleLink + '\'' + ", imageUrl='" + imageUrl + '\'' + ", thumbUrl='" + thumbUrl
+		+ '\'' + ", markdownAttributes=" + markdownAttributes + ", fields=" + fields + '}';
+    }
 }


### PR DESCRIPTION
Added support to mark attributes of a SlackAttachment as containing
markdown.