### PR TITLE
remove slack's URL requirement - allows to use with MatterMost and ot…

### DIFF
--- a/src/main/java/net/gpedro/integrations/slack/SlackApi.java
+++ b/src/main/java/net/gpedro/integrations/slack/SlackApi.java
@@ -42,9 +42,6 @@ public class SlackApi {
 		if (service == null) {
 		    throw new IllegalArgumentException(
 		            "Missing WebHook URL Configuration @ SlackApi");
-		} else if (!service.startsWith("https://hooks.slack.com/services/")) {
-		    throw new IllegalArgumentException(
-		            "Invalid Service URL. WebHook URL Format: https://hooks.slack.com/services/{id_1}/{id_2}/{token}");
 		}
 		
 		if(proxy == null) {


### PR DESCRIPTION
…her Slack-compatible clones